### PR TITLE
Enable fluent pagination features for paginated collections

### DIFF
--- a/rest/src/main/java/com/abiquo/apiclient/domain/PageIterator.java
+++ b/rest/src/main/java/com/abiquo/apiclient/domain/PageIterator.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2008 Abiquo Holdings S.L.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.abiquo.apiclient.domain;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Iterator;
+
+import com.abiquo.apiclient.ApiClient;
+import com.abiquo.model.rest.RESTLink;
+import com.abiquo.model.transport.SingleResourceTransportDto;
+import com.abiquo.model.transport.WrapperDto;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
+
+/**
+ * An {@link Iterator} that is capable of advancing between the pages of a paginated collection.
+ * <p>
+ * To create this iterator use the {{@link #flatten(ApiClient, WrapperDto)} method.
+ * 
+ * @author Ignasi Barrera
+ */
+public class PageIterator<T extends WrapperDto< ? extends SingleResourceTransportDto>> extends
+    AbstractIterator<T>
+{
+    /**
+     * Creates an iterator capable of advancing over the elements of a paginated collection, and
+     * lazily fetch new pages as they are needed.
+     * 
+     * @param api The API client used to fetch new pages when needed.
+     * @param dto The collection to iterate.
+     * @return An iterator capable of advancing between pages.
+     */
+    public static <T extends SingleResourceTransportDto, W extends WrapperDto<T>> Iterable<T> flatten(
+        final ApiClient api, final W dto)
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                final PageIterator<W> pageIterator = new PageIterator<W>(api, dto);
+                return Iterators.concat(new AbstractIterator<Iterator<T>>()
+                {
+                    @Override
+                    protected Iterator<T> computeNext()
+                    {
+                        return pageIterator.hasNext() ? pageIterator.next().getCollection()
+                            .iterator() : endOfData();
+                    }
+                });
+            }
+        };
+    }
+
+    private final ApiClient api;
+
+    private T currentPage;
+
+    private boolean unread;
+
+    /* For internal use only. Use the factory methods. */
+    private PageIterator(final ApiClient api, final T initialPage)
+    {
+        this.api = checkNotNull(api, "api cannot be null");
+        this.currentPage = checkNotNull(initialPage, "initialPage cannot be null");
+        // First iteration has to return the initial page without fetching a new one
+        this.unread = true;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected T computeNext()
+    {
+        if (unread)
+        {
+            try
+            {
+                return currentPage;
+            }
+            finally
+            {
+                // Set this in a finally block to only set it after the value has been returned
+                unread = false;
+            }
+        }
+        else
+        {
+            RESTLink next = currentPage.searchLink("next");
+            if (next == null)
+            {
+                return endOfData();
+            }
+            else
+            {
+                currentPage =
+                    api.getClient().get(next.getHref(), currentPage.getMediaType(),
+                        (Class<T>) currentPage.getClass());
+                return currentPage;
+            }
+        }
+    }
+}

--- a/rest/src/test/java/com/abiquo/apiclient/domain/PageIteratorTest.java
+++ b/rest/src/test/java/com/abiquo/apiclient/domain/PageIteratorTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2008 Abiquo Holdings S.L.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.abiquo.apiclient.domain;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Iterator;
+
+import org.testng.annotations.Test;
+
+import com.abiquo.apiclient.BaseMockTest;
+import com.abiquo.model.rest.RESTLink;
+import com.abiquo.model.transport.SingleResourceTransportDto;
+import com.abiquo.server.core.infrastructure.DatacenterDto;
+import com.abiquo.server.core.infrastructure.DatacentersDto;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+@Test
+public class PageIteratorTest extends BaseMockTest
+{
+    public void testOnePageDoesNotPerformRequests() throws Exception
+    {
+        DatacenterDto datacenter = new DatacenterDto();
+        DatacenterDto datacenter2 = new DatacenterDto();
+        DatacentersDto datacenters = new DatacentersDto();
+        datacenters.add(datacenter);
+        datacenters.add(datacenter2);
+
+        server.play();
+
+        Iterator<DatacenterDto> it = PageIterator.flatten(newApiClient(), datacenters).iterator();
+
+        assertTrue(it.hasNext());
+        assertEquals(it.next(), datacenter);
+        assertTrue(it.hasNext());
+        assertEquals(it.next(), datacenter2);
+        assertFalse(it.hasNext());
+
+        assertEquals(server.getRequestCount(), 0);
+    }
+
+    public void testMultiplePagesAreLazilyFetched() throws Exception
+    {
+        MockResponse response = new MockResponse() //
+            .setHeader("Content-Type", DatacentersDto.SHORT_MEDIA_TYPE_JSON) //
+            .setBody(payloadFromResource("dcs.json"));
+        server.enqueue(response);
+        server.play();
+
+        DatacenterDto datacenter = new DatacenterDto();
+        DatacenterDto datacenter2 = new DatacenterDto();
+        DatacentersDto datacenters = new DatacentersDto();
+        datacenters.add(datacenter);
+        datacenters.add(datacenter2);
+        datacenters.addLink(new RESTLink("next", server.getUrl("")
+            + "/api/admin/datacenters?startwith=2"));
+
+        Iterator<DatacenterDto> it = PageIterator.flatten(newApiClient(), datacenters).iterator();
+
+        // First two elements are in the initial page. No request should be performed, as the
+        // elements in the second page are still not needed
+        assertTrue(it.hasNext());
+        assertEquals(it.next(), datacenter);
+        assertTrue(it.hasNext());
+        assertEquals(it.next(), datacenter2);
+        assertEquals(server.getRequestCount(), 0);
+
+        // There is a second page, so it should be fetched now and its elements returned as normal
+        // elements in the collection
+        assertTrue(it.hasNext());
+        assertNotNull(it.next());
+        assertTrue(it.hasNext());
+        assertNotNull(it.next());
+        assertEquals(server.getRequestCount(), 1);
+
+        RecordedRequest request = server.takeRequest();
+        assertRequest(request, "GET", "/api/admin/datacenters?startwith=2");
+        assertAccept(request, DatacentersDto.SHORT_MEDIA_TYPE_JSON,
+            SingleResourceTransportDto.API_VERSION);
+
+        // After reading the second page, there are no elements left
+        assertFalse(it.hasNext());
+    }
+}


### PR DESCRIPTION
Adds a custom iterator to enable fluent pagination features for paginated collections. This will make it transparent to iterate over the elements of a paginated collection, fetching pages lazily as they are needed, once the iteration reaches the end of the current page.

Any *collection Dto* can be transformed into a fluent page iterator as shown in the following example:

```java
// An api client is needed by the iterator to fetch the pages as they are needed
ApiClient api =  ApiClient.builder()
    .endpoint("http://localhost/api")
    .credentials("username", "password")
.    build();

VirtualDatacentersDto vdcList = api.getCloudApi().listVirtualDatacenters();

// Fattening the collection will create an Iterable that will fetch pages as soon as
// they are needed (not before) to iterate the entire collection. It is a regular Iterable,
// making all pagination stuff is transparent and hidden to the user.
Iterable<VirtualDatacenterDto> vdcs = PageIterator.flatten(api, vdcList);
for (VirtualDatacenterDto vdc : vdcs) {
    System.out.println("VDC: " + vdc.getName());
}
```
