### PR TITLE
Fix #20. Do not retry on 401 errors.

### DIFF
--- a/rest/src/main/java/com/abiquo/apiclient/RestClient.java
+++ b/rest/src/main/java/com/abiquo/apiclient/RestClient.java
@@ -24,7 +24,6 @@ import static com.google.common.collect.Maps.transformValues;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import java.net.Proxy;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Map;
@@ -54,7 +53,6 @@ import com.google.common.base.Throwables;
 import com.google.common.net.HttpHeaders;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.Uninterruptibles;
-import com.squareup.okhttp.Authenticator;
 import com.squareup.okhttp.Credentials;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
@@ -93,22 +91,6 @@ public class RestClient
             client.setHostnameVerifier(sslConfiguration.hostnameVerifier());
             client.setSslSocketFactory(sslConfiguration.sslContext().getSocketFactory());
         }
-
-        client.setAuthenticator(new Authenticator()
-        {
-            @Override
-            public Request authenticate(final Proxy proxy, final Response response)
-            {
-                return response.request().newBuilder()
-                    .header(HttpHeaders.AUTHORIZATION, authHeader).build();
-            }
-
-            @Override
-            public Request authenticateProxy(final Proxy proxy, final Response response)
-            {
-                return null;
-            }
-        });
     }
 
     public <T extends SingleResourceTransportDto> T edit(final T dto)


### PR DESCRIPTION
The Abiquo API allows anonymous access for certain resources (OPTIONS, to follow the CORS standard). 

That makes unauthenticated requests with other verbs return a 403 (forbidden) instead of a 401. Since OkHttp does not call the Authenticator upon 403 failures, we have to explicitly add the basic auth header in each request by default. The authenticator will only be called if there is a 401, and that will only happen when the provided credentials are invalid, so just make sure the authenticator never tries to retry requests for 401 responses.

/cc @apuig 